### PR TITLE
Fix parsing error on no dependencies targets

### DIFF
--- a/Sources/PodExtractor/Module+Podfile.swift
+++ b/Sources/PodExtractor/Module+Podfile.swift
@@ -25,10 +25,10 @@ struct Podfile: Decodable {
     
     struct ChildrenDefinition: Decodable {
         let name: String
-        let dependencies: [Dependency]
+        let dependencies: [Dependency]?
         let children: [ChildrenDefinition]?
         var asTarget: [Module] {
-            let target = Module(name: name, dependencies: dependencies.compactMap(\.name))
+            let target = Module(name: name, dependencies: dependencies?.compactMap(\.name) ?? [])
             let children = children ?? []
             return children.reduce([target]) { $0 + $1.asTarget }
         }

--- a/Sources/jungle/Commands/Main.swift
+++ b/Sources/jungle/Commands/Main.swift
@@ -5,7 +5,7 @@ struct Jungle: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "jungle",
         abstract: "Displays dependency statistics",
-        version: "1.0.0",
+        version: "1.0.1",
         subcommands: [HistoryCommand.self, CompareCommand.self, GraphCommand.self],
         defaultSubcommand: CompareCommand.self
     )

--- a/Sources/jungle/Models/Outputs.swift
+++ b/Sources/jungle/Models/Outputs.swift
@@ -35,12 +35,10 @@ struct CompareStatsOutput: Codable {
     let name: String
     let moduleCount: Int
     let complexity: Int
-    let modules: Int
     
     init(label: String, graph: Graph) {
         name = label
         moduleCount = graph.nodes.count
         complexity = graph.multiGraphComplexity
-        modules = graph.nodes.count
     }
 }

--- a/Tests/PodExtractorTests/PodExtractorTests.swift
+++ b/Tests/PodExtractorTests/PodExtractorTests.swift
@@ -80,7 +80,7 @@ final class PodExtractorTests: XCTestCase {
         XCTAssertEqual(modules.count, 2)
     }
     
-    func testTargetModulesFromPodfileLock() throws {
+    func testTargetModulesFromPodfile() throws {
         
         // Example Podfile from https://github.com/artsy/eidolon
         let podfile = """
@@ -241,5 +241,101 @@ final class PodExtractorTests: XCTestCase {
                                                    "Forgeries",
                                                    "RxBlocking"]
         )
+    }
+    
+    func testTargetModulesFromPodfileNoDependenciesInChildren() throws {
+        
+        let podfile = """
+        {
+          "target_definitions": [
+            {
+              "name": "Pods",
+              "abstract": true,
+              "platform": {
+                "ios": "16.0"
+              },
+              "uses_frameworks": {
+                "linkage": "dynamic",
+                "packaging": "framework"
+              },
+              "inhibit_warnings": {
+                "all": true
+              },
+              "children": [
+                {
+                  "name": "FromCocoaToSPM",
+                  "inhibit_warnings": {
+                    "for_pods": [
+                      "Appboy-iOS-SDK",
+                      "Alamofire",
+                      "Amplitude"
+                    ]
+                  },
+                  "dependencies": [
+                    {
+                      "Appboy-iOS-SDK": [
+                        "4.5.1"
+                      ]
+                    },
+                    {
+                      "Alamofire": [
+                        "5.6.1"
+                      ]
+                    },
+                    {
+                      "Amplitude": [
+                        "8.11.0"
+                      ]
+                    },
+                    {
+                      "AppFeature": [
+                        {
+                          "path": "InternalDependencies/AppFeature"
+                        }
+                      ]
+                    },
+                    {
+                      "ProductsFeature": [
+                        {
+                          "path": "InternalDependencies/ProductsFeature"
+                        }
+                      ]
+                    },
+                    {
+                      "SettingsFeature": [
+                        {
+                          "path": "InternalDependencies/SettingsFeature"
+                        }
+                      ]
+                    },
+                    {
+                      "UIComponents": [
+                        {
+                          "path": "InternalDependencies/UIComponents"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": [
+                    {
+                      "name": "FromCocoaToSPMTests",
+                      "abstract": false,
+                      "inheritance": "search_paths"
+                    },
+                    {
+                      "name": "FromCocoaToSPMUITests"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """
+        
+        let targets = try modulesFromJSONPodfile(podfile)
+        
+        XCTAssertEqual(targets.count, 3)
+ 
     }
 }


### PR DESCRIPTION
- Fix a `failedParsingPod` error when parsing the `Podfile` and the target do not contains any dependencies 
- removed extra property in the compare command (modules)