### PR TITLE
ignore failed task in the TaskGroup

### DIFF
--- a/Sources/jungle/Commands/Main.swift
+++ b/Sources/jungle/Commands/Main.swift
@@ -5,7 +5,7 @@ struct Jungle: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "jungle",
         abstract: "Displays dependency statistics",
-        version: "1.0.2",
+        version: "1.0.3",
         subcommands: [HistoryCommand.self, CompareCommand.self, GraphCommand.self],
         defaultSubcommand: CompareCommand.self
     )


### PR DESCRIPTION
History command can fail with really old commits, where maybe the `Podfile` format is not supported now. At this moment, we're going to skip them.