### PR TITLE
fix zsh issue in shell

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Shell/Shell.swift
+++ b/Sources/Shell/Shell.swift
@@ -12,7 +12,7 @@ import Foundation
         task.standardError = errorPipe
     }
     task.standardOutput = pipe
-    task.arguments = ["--login", "-c", command]
+    task.arguments = ["-c", command]
     task.launchPath = "/bin/zsh"
     task.standardInput = nil
     if let directory = directory {

--- a/Sources/jungle/Commands/Main.swift
+++ b/Sources/jungle/Commands/Main.swift
@@ -5,7 +5,7 @@ struct Jungle: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "jungle",
         abstract: "SwiftPM and Cocoapods based projects complexity analyzer.",
-        version: "2.1.0",
+        version: "2.1.1",
         subcommands: [HistoryCommand.self, CompareCommand.self, GraphCommand.self, ModulesCommand.self],
         defaultSubcommand: CompareCommand.self
     )


### PR DESCRIPTION
This fixes an issue which makes `Shell` module to  use a Login shell instead of a interactive one, blocking the loading of `.zshrc` shell configuration files and ruby/bundler dependant variables.