### PR TITLE
fix podextractor for some test targets

### DIFF
--- a/Sources/jungle/Commands/Main.swift
+++ b/Sources/jungle/Commands/Main.swift
@@ -5,7 +5,7 @@ struct Jungle: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "jungle",
         abstract: "SwiftPM and Cocoapods based projects complexity analyzer.",
-        version: "2.2.0",
+        version: "2.2.1",
         subcommands: [HistoryCommand.self, CompareCommand.self, GraphCommand.self, ModulesCommand.self, DependantCommand.self],
         defaultSubcommand: CompareCommand.self
     )

--- a/Tests/PodExtractorTests/PodExtractorTests.swift
+++ b/Tests/PodExtractorTests/PodExtractorTests.swift
@@ -28,6 +28,23 @@ final class PodExtractorTests: XCTestCase {
 
         XCTAssertEqual(modules.count, 1)
     }
+    
+    func testExtractModulesNotIgnoringTests() throws {
+        let podfile = """
+        PODS:
+          - A (1.0.0)
+          - B (1.0.0)
+          - B/Tests (1.0.0)
+        """
+
+        let modules = try extractModulesFromPodfileLock(podfile, excludeTests: false)
+
+        let libraries = modules.filter({ $0.type == .library })
+        let tests = modules.filter({ $0.type == .test })
+        
+        XCTAssertEqual(libraries.count, 2)
+        XCTAssertEqual(tests.count, 1)
+    }
 
     func testExtractModulesIgnoresExternals() throws {
         let podfile = """


### PR DESCRIPTION
This resolves a situations where some pod test targets are not being considered as .test ones, but as .libraries, causing some issues in dependency inspection.